### PR TITLE
Fix typo gzip size from `890MB` to `890KB`

### DIFF
--- a/source/wink-nlp/language-models.html.markdown.erb
+++ b/source/wink-nlp/language-models.html.markdown.erb
@@ -3,7 +3,7 @@ title: Language models
 ---
 
 # Language models
-WinkNLP comes with pre-trained language models with gzipped sizes starting from ~890MB (expanded sizes less than 3MB) onwards:
+WinkNLP comes with pre-trained language models with gzipped sizes starting from ~890KB (expanded sizes less than 3MB) onwards:
 
 ## [wink-eng-lite-model](https://github.com/winkjs/wink-eng-lite-model)
 


### PR DESCRIPTION
The subtitle says "gzipped sizes starting from ~890MB" while the actual size stated below is 890KB (which makes more sense I guess).